### PR TITLE
Addition of Attributes introduced in Continue Watching 2.0

### DIFF
--- a/read/app/build.gradle
+++ b/read/app/build.gradle
@@ -51,7 +51,7 @@ android {
 dependencies {
 
     // Engage SDK
-    implementation 'com.google.android.engage:engage-core:1.2.0'
+    implementation 'com.google.android.engage:engage-core:1.4.0'
 
     // Oss Plugin
     implementation "com.google.android.gms:play-services-oss-licenses:17.0.0"

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
@@ -44,6 +44,7 @@ public final class EbookToEntityConverter {
     Ebook ebook = new Ebook(ebookId);
     EbookEntity.Builder entityBuilder = new EbookEntity.Builder();
     entityBuilder
+        .setEntityId(Integer.toString(ebook.getId()))
         .setName(ebook.getName())
         .addAuthors(ebook.getAuthors())
         .setActionLinkUri(Uri.parse(ENGAGE_SDK_DOCS_URL))

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
@@ -1,17 +1,3 @@
-/* Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.google.samples.quickstart.engagesdksamples.read.converters;
 
 import static com.google.samples.quickstart.engagesdksamples.read.converters.Constants.ENGAGE_SDK_DOCS_URL;
@@ -44,7 +30,6 @@ public final class EbookToEntityConverter {
     Ebook ebook = new Ebook(ebookId);
     EbookEntity.Builder entityBuilder = new EbookEntity.Builder();
     entityBuilder
-        .setEntityId(Integer.toString(ebook.getId()))
         .setName(ebook.getName())
         .addAuthors(ebook.getAuthors())
         .setActionLinkUri(Uri.parse(ENGAGE_SDK_DOCS_URL))

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/EbookToEntityConverter.java
@@ -1,3 +1,17 @@
+/* Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.samples.quickstart.engagesdksamples.read.converters;
 
 import static com.google.samples.quickstart.engagesdksamples.read.converters.Constants.ENGAGE_SDK_DOCS_URL;

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
@@ -30,7 +30,7 @@ public class ResourceIdToImage {
         .setImageUri(getImageUriFromResourceId(imageResourceId))
         .setImageHeightInPixel(IMAGE_HEIGHT)
         .setImageWidthInPixel(IMAGE_WIDTH)
-        .setImageTheme(ImageTheme.IMAGE_THEME_UNSPECIFIED)
+        .setImageTheme(ImageTheme.IMAGE_THEME_LIGHT)
         .build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
@@ -1,3 +1,17 @@
+/* Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.samples.quickstart.engagesdksamples.read.converters;
 
 import static com.google.samples.quickstart.engagesdksamples.read.converters.Constants.IMAGE_HEIGHT;

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
@@ -29,6 +29,7 @@ public class ResourceIdToImage {
         .setImageUri(getImageUriFromResourceId(imageResourceId))
         .setImageHeightInPixel(IMAGE_HEIGHT)
         .setImageWidthInPixel(IMAGE_WIDTH)
+        .setImageTheme(0)
         .build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
@@ -20,6 +20,7 @@ import static com.google.samples.quickstart.engagesdksamples.read.converters.Con
 
 import android.net.Uri;
 import com.google.android.engage.common.datamodel.Image;
+import com.google.android.engage.common.datamodel.ImageTheme;
 
 /** Converts a ResourceId to an Engage Image. */
 public class ResourceIdToImage {
@@ -29,7 +30,7 @@ public class ResourceIdToImage {
         .setImageUri(getImageUriFromResourceId(imageResourceId))
         .setImageHeightInPixel(IMAGE_HEIGHT)
         .setImageWidthInPixel(IMAGE_WIDTH)
-        .setImageTheme(0)
+        .setImageTheme(ImageTheme.IMAGE_THEME_UNSPECIFIED)
         .build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/converters/ResourceIdToImage.java
@@ -1,17 +1,3 @@
-/* Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.google.samples.quickstart.engagesdksamples.read.converters;
 
 import static com.google.samples.quickstart.engagesdksamples.read.converters.Constants.IMAGE_HEIGHT;
@@ -20,7 +6,6 @@ import static com.google.samples.quickstart.engagesdksamples.read.converters.Con
 
 import android.net.Uri;
 import com.google.android.engage.common.datamodel.Image;
-import com.google.android.engage.common.datamodel.ImageTheme;
 
 /** Converts a ResourceId to an Engage Image. */
 public class ResourceIdToImage {
@@ -30,7 +15,6 @@ public class ResourceIdToImage {
         .setImageUri(getImageUriFromResourceId(imageResourceId))
         .setImageHeightInPixel(IMAGE_HEIGHT)
         .setImageWidthInPixel(IMAGE_WIDTH)
-        .setImageTheme(ImageTheme.IMAGE_THEME_LIGHT)
         .build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
@@ -1,17 +1,3 @@
-/* Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.google.samples.quickstart.engagesdksamples.read.publish;
 
 class Constants {
@@ -44,8 +30,6 @@ class Constants {
   static final String SET_CONTINUATION = "SET_CONTINUATION";
 
   static final String SET_USER_MANAGEMENT = "SET_USER_MANAGEMENT";
-  static final String ACCOUNT_ID = "ACCOUNT_ID";
-  static final String PROFILE_ID = "PROFILE_ID";
 
   private Constants() {}
 }

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
@@ -44,6 +44,8 @@ class Constants {
   static final String SET_CONTINUATION = "SET_CONTINUATION";
 
   static final String SET_USER_MANAGEMENT = "SET_USER_MANAGEMENT";
+  static final String ACCOUNT_ID = "ACCOUNT_ID";
+  static final String PROFILE_ID = "PROFILE_ID";
 
   private Constants() {}
 }

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/Constants.java
@@ -1,3 +1,17 @@
+/* Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.samples.quickstart.engagesdksamples.read.publish;
 
 class Constants {

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
@@ -1,3 +1,17 @@
+/* Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.samples.quickstart.engagesdksamples.read.publish;
 
 import androidx.annotation.NonNull;

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
@@ -16,6 +16,7 @@ package com.google.samples.quickstart.engagesdksamples.read.publish;
 
 import androidx.annotation.NonNull;
 import com.google.android.engage.books.datamodel.EbookEntity;
+import com.google.android.engage.common.datamodel.AccountProfile;
 import com.google.android.engage.common.datamodel.ContinuationCluster;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -50,6 +51,9 @@ final class GetContinuationCluster {
         clusterBuilder.addEntity(entity);
       }
     }
+    clusterBuilder.setUserConsentToSyncAcrossDevices(true);
+    clusterBuilder.setAccountProfile(
+            new AccountProfile(Constants.ACCOUNT_ID, Constants.PROFILE_ID));
     return clusterBuilder.build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
@@ -53,7 +53,11 @@ final class GetContinuationCluster {
     }
     clusterBuilder.setUserConsentToSyncAcrossDevices(true);
     clusterBuilder.setAccountProfile(
-            new AccountProfile(Constants.ACCOUNT_ID, Constants.PROFILE_ID));
+            new AccountProfile.Builder()
+                    .setAccountId(Constants.ACCOUNT_ID)
+                    .setProfileId(Constants.PROFILE_ID)
+                    .build()
+            );
     return clusterBuilder.build();
   }
 

--- a/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
+++ b/read/app/src/main/java/com/google/samples/quickstart/engagesdksamples/read/publish/GetContinuationCluster.java
@@ -1,22 +1,7 @@
-/* Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.google.samples.quickstart.engagesdksamples.read.publish;
 
 import androidx.annotation.NonNull;
 import com.google.android.engage.books.datamodel.EbookEntity;
-import com.google.android.engage.common.datamodel.AccountProfile;
 import com.google.android.engage.common.datamodel.ContinuationCluster;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -51,13 +36,6 @@ final class GetContinuationCluster {
         clusterBuilder.addEntity(entity);
       }
     }
-    clusterBuilder.setUserConsentToSyncAcrossDevices(true);
-    clusterBuilder.setAccountProfile(
-            new AccountProfile.Builder()
-                    .setAccountId(Constants.ACCOUNT_ID)
-                    .setProfileId(Constants.PROFILE_ID)
-                    .build()
-            );
     return clusterBuilder.build();
   }
 

--- a/watch/app/build.gradle
+++ b/watch/app/build.gradle
@@ -69,7 +69,7 @@ android {
 
 dependencies {
     // Engage SDK
-    implementation 'com.google.android.engage:engage-core:1.2.0'
+    implementation 'com.google.android.engage:engage-core:1.4.0'
 
     // OSS Plugin
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'

--- a/watch/app/src/androidTest/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverterTest.kt
+++ b/watch/app/src/androidTest/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverterTest.kt
@@ -15,6 +15,7 @@
 package com.google.samples.quickstart.engagesdksamples.watch
 
 import android.net.Uri
+import com.google.android.engage.common.datamodel.PlatformType
 import com.google.samples.quickstart.engagesdksamples.watch.data.converters.ItemToEntityConverter
 import com.google.samples.quickstart.engagesdksamples.watch.data.model.MovieItem
 import org.junit.Test
@@ -29,10 +30,10 @@ class ItemToEntityConverterTest {
     assert(movieEntity.name == movieItem.movieName)
     assert(movieEntity.playBackUri == Uri.parse(movieItem.playbackUri))
     assert(movieEntity.releaseDateEpochMillis.get() == movieItem.releaseDate)
-    assert(movieEntity.offerPrice.get() == movieItem.offerPrice)
     assert(movieEntity.durationMillis == movieItem.durationMillis)
     assert(movieEntity.genres[0] == movieItem.genre)
-    assert(movieEntity.contentRatings[0] == movieItem.contentRatings)
+    assert(movieEntity.contentRatings[0].rating == movieItem.contentRating)
+    assert(movieEntity.contentRatings[0].agencyName == movieItem.contentRatingAgency)
   }
 
   @Test
@@ -47,10 +48,10 @@ class ItemToEntityConverterTest {
     assert(inProgressMovieEntity.name == inProgressMovieItem.movieName)
     assert(inProgressMovieEntity.playBackUri == Uri.parse(inProgressMovieItem.playbackUri))
     assert(inProgressMovieEntity.releaseDateEpochMillis.get() == inProgressMovieItem.releaseDate)
-    assert(inProgressMovieEntity.offerPrice.get() == inProgressMovieItem.offerPrice)
     assert(inProgressMovieEntity.durationMillis == inProgressMovieItem.durationMillis)
     assert(inProgressMovieEntity.genres[0] == inProgressMovieItem.genre)
-    assert(inProgressMovieEntity.contentRatings[0] == inProgressMovieItem.contentRatings)
+    assert(inProgressMovieEntity.contentRatings[0].rating == inProgressMovieItem.contentRating)
+    assert(inProgressMovieEntity.contentRatings[0].agencyName == inProgressMovieItem.contentRatingAgency)
     assert(
       inProgressMovieEntity.lastEngagementTimeMillis.get() ==
         inProgressMovieItem.lastEngagementTimeMillis
@@ -69,12 +70,14 @@ class ItemToEntityConverterTest {
         movieName = "Title1",
         landscapePoster = R.drawable.blue,
         playbackUri = "https://tv.com/playback/1",
+        platformSpecificPlaybackUri = "https://tv.com/playback/1",
+        platformType =  PlatformType.TYPE_ANDROID_TV,
         releaseDate = 1633032875L,
         availability = 1,
-        offerPrice = "0.99",
         durationMillis = 123456789L,
         genre = "mystery",
-        contentRatings = "PG-13"
+        contentRating = "PG-13",
+        contentRatingAgency = "ContentRatingAgency"
       )
 
     private var inProgressMovieItem =
@@ -83,12 +86,14 @@ class ItemToEntityConverterTest {
         movieName = "Title2",
         landscapePoster = R.drawable.blue,
         playbackUri = "https://tv.com/playback/1",
+        platformSpecificPlaybackUri = "https://tv.com/playback/1",
+        platformType =  PlatformType.TYPE_ANDROID_TV,
         releaseDate = 2744143986L,
         availability = 2,
-        offerPrice = "1.99",
         durationMillis = 234567891L,
         genre = "comedy",
-        contentRatings = "R"
+        contentRating = "R",
+        contentRatingAgency = "ContentRatingAgency"
       )
   }
 }

--- a/watch/app/src/androidTest/java/com/google/samples/quickstart/engagesdksamples/watch/publish/EngageServiceWorkerTest.kt
+++ b/watch/app/src/androidTest/java/com/google/samples/quickstart/engagesdksamples/watch/publish/EngageServiceWorkerTest.kt
@@ -22,6 +22,7 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.testing.TestListenableWorkerBuilder
 import androidx.work.workDataOf
+import com.google.android.engage.common.datamodel.PlatformType
 import com.google.android.engage.service.AppEngageErrorCode
 import com.google.android.engage.service.AppEngageException
 import com.google.android.engage.service.AppEngagePublishClient
@@ -64,12 +65,14 @@ class EngageServiceWorkerTest {
           movieName = "Test",
           landscapePoster = 1,
           playbackUri = "Test",
+          platformSpecificPlaybackUri = "Test",
+          platformType =  PlatformType.TYPE_ANDROID_TV,
           releaseDate = 1L,
           availability = 1,
-          offerPrice = "String",
           durationMillis = 1L,
           genre = "Test",
-          contentRatings = "Test"
+          contentRatingAgency = "ContentRatingAgency",
+          contentRating = "Test"
         )
         .apply {
           currentlyWatching = true

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
@@ -15,8 +15,13 @@
 package com.google.samples.quickstart.engagesdksamples.watch.data.converters
 
 import android.net.Uri
+import com.google.android.engage.common.datamodel.DisplayTimeWindow
 import com.google.android.engage.common.datamodel.Image
+import com.google.android.engage.common.datamodel.ImageTheme
+import com.google.android.engage.common.datamodel.PlatformSpecificUri
+import com.google.android.engage.common.datamodel.Rating
 import com.google.android.engage.video.datamodel.MovieEntity
+import com.google.android.engage.video.datamodel.RatingSystem
 import com.google.samples.quickstart.engagesdksamples.watch.data.model.MovieItem
 
 const val PACKAGE_NAME: String = "com.google.samples.quickstart.engagesdksamples.watch"
@@ -34,6 +39,7 @@ object ItemToEntityConverter {
     val movieBuilder: MovieEntity.Builder =
       MovieEntity.Builder()
         .setName(movie.movieName)
+        .setEntityId(movie.id)
         .addPosterImage(
           Image.Builder()
             .setImageUri(
@@ -41,15 +47,29 @@ object ItemToEntityConverter {
             )
             .setImageWidthInPixel(408)
             .setImageHeightInPixel(960)
+            .setImageTheme(ImageTheme.IMAGE_THEME_DARK)
             .build()
         )
         .setPlayBackUri(Uri.parse(movie.playbackUri))
+        .addPlatformSpecificPlaybackUri(
+          PlatformSpecificUri(Uri.parse(movie.platformSpecificPlaybackUri), movie.platformType)
+        )
         .setReleaseDateEpochMillis(movie.releaseDate)
         .setAvailability(movie.availability)
-        .setOfferPrice(movie.offerPrice)
         .setDurationMillis(movie.durationMillis)
         .addGenre(movie.genre)
-        .addContentRating(movie.contentRatings)
+        .addAvailabilityTimeWindow(
+          DisplayTimeWindow.Builder()
+            .setStartTimestampMillis(movie.startTimestampMillis)
+            .setEndTimestampMillis(movie.endTimestampMillis)
+            .build()
+        )
+        .addContentRating(
+          RatingSystem.Builder()
+            .setAgencyName(movie.contentRatingAgency)
+            .setRating(movie.contentRating)
+            .build()
+        )
     if (movie.currentlyWatching) {
       movieBuilder
         .setWatchNextType(movie.watchNextType)

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
@@ -46,12 +46,15 @@ object ItemToEntityConverter {
             )
             .setImageWidthInPixel(408)
             .setImageHeightInPixel(960)
-            .setImageTheme(ImageTheme.IMAGE_THEME_UNSPECIFIED)
+            .setImageTheme(ImageTheme.IMAGE_THEME_LIGHT)
             .build()
         )
         .setPlayBackUri(Uri.parse(movie.playbackUri))
         .addPlatformSpecificPlaybackUri(
-          PlatformSpecificUri(Uri.parse(movie.platformSpecificPlaybackUri), movie.platformType)
+          PlatformSpecificUri.Builder()
+            .setActionUri(Uri.parse(movie.platformSpecificPlaybackUri))
+            .setPlatformType(movie.platformType)
+            .build()
         )
         .setReleaseDateEpochMillis(movie.releaseDate)
         .setAvailability(movie.availability)
@@ -59,8 +62,8 @@ object ItemToEntityConverter {
         .addGenre(movie.genre)
         .addAvailabilityTimeWindow(
           DisplayTimeWindow.Builder()
-            .setStartTimestampMillis(movie.startTimestampMillis)
-            .setEndTimestampMillis(movie.endTimestampMillis)
+            .setStartTimestampMillis(movie.availabilityStartTimeMillis)
+            .setEndTimestampMillis(movie.availabilityEndTimeMillis)
             .build()
         )
         .addContentRating(

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/converters/ItemToEntityConverter.kt
@@ -19,7 +19,6 @@ import com.google.android.engage.common.datamodel.DisplayTimeWindow
 import com.google.android.engage.common.datamodel.Image
 import com.google.android.engage.common.datamodel.ImageTheme
 import com.google.android.engage.common.datamodel.PlatformSpecificUri
-import com.google.android.engage.common.datamodel.Rating
 import com.google.android.engage.video.datamodel.MovieEntity
 import com.google.android.engage.video.datamodel.RatingSystem
 import com.google.samples.quickstart.engagesdksamples.watch.data.model.MovieItem
@@ -47,7 +46,7 @@ object ItemToEntityConverter {
             )
             .setImageWidthInPixel(408)
             .setImageHeightInPixel(960)
-            .setImageTheme(ImageTheme.IMAGE_THEME_DARK)
+            .setImageTheme(ImageTheme.IMAGE_THEME_UNSPECIFIED)
             .build()
         )
         .setPlayBackUri(Uri.parse(movie.playbackUri))

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/MovieItem.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/MovieItem.kt
@@ -24,18 +24,22 @@ data class MovieItem(
   @PrimaryKey @ColumnInfo(name = ID) val id: String,
   @ColumnInfo(name = MOVIE_NAME) val movieName: String,
   @ColumnInfo(name = LANDSCAPE_POSTER) var landscapePoster: Int, // Resource ID
+  @ColumnInfo(name = PLATFORM_TYPE) val platformType: Int,
+  @ColumnInfo(name = PLATFORM_SPECIFIC_PLAYBACK_URI) val platformSpecificPlaybackUri: String,
   @ColumnInfo(name = PLAYBACK_URI) val playbackUri: String,
   @ColumnInfo(name = RELEASE_DATE) val releaseDate: Long,
   @ColumnInfo(name = AVAILABILITY) val availability: Int, // ContentAvailability.AVAILABILITY_TYPE
-  @ColumnInfo(name = OFFER_PRICE) var offerPrice: String,
   @ColumnInfo(name = DURATION_MILLIS) val durationMillis: Long, // Epoch ms
   @ColumnInfo(name = GENRE) val genre: String,
-  @ColumnInfo(name = CONTENT_RATINGS) val contentRatings: String
+  @ColumnInfo(name = CONTENT_RATING_AGENCY) val contentRatingAgency: String,
+  @ColumnInfo(name = CONTENT_RATING) val contentRating: String
 ) {
   @ColumnInfo(name = CURRENTLY_WATCHING) var currentlyWatching: Boolean = false
   @ColumnInfo(name = WATCH_NEXT_TYPE) var watchNextType: Int = WatchNextType.TYPE_UNKNOWN
   @ColumnInfo(name = LAST_ENGAGEMENT_TIME_MILLIS)
   var lastEngagementTimeMillis: Long = 0L // Epoch ms
+  var startTimestampMillis: Long = 0L
+  var endTimestampMillis: Long = 0L
   @ColumnInfo(name = LAST_PLAYBACK_TIME_MILLIS) var lastPlaybackTimeMillis: Long = 0L // Epoch ms
 
   companion object {
@@ -43,13 +47,15 @@ data class MovieItem(
     const val ID = "id"
     const val MOVIE_NAME = "movie_name"
     const val LANDSCAPE_POSTER = "landscape_poster"
+    const val PLATFORM_TYPE = "platform_type"
+    const val PLATFORM_SPECIFIC_PLAYBACK_URI = "platform_specific_playback_uri"
     const val PLAYBACK_URI = "playback_uri"
     const val RELEASE_DATE = "release_date"
     const val AVAILABILITY = "availability"
-    const val OFFER_PRICE = "offer_price"
     const val DURATION_MILLIS = "duration_millis"
     const val GENRE = "genre"
-    const val CONTENT_RATINGS = "content_ratings"
+    const val CONTENT_RATING_AGENCY = "content_rating_agency"
+    const val CONTENT_RATING = "content_rating"
     const val CURRENTLY_WATCHING = "currently_watching"
     const val WATCH_NEXT_TYPE = "watch_next_type"
     const val LAST_ENGAGEMENT_TIME_MILLIS = "last_engagement_time_millis"

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/MovieItem.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/MovieItem.kt
@@ -40,6 +40,8 @@ data class MovieItem(
   var lastEngagementTimeMillis: Long = 0L // Epoch ms
   var startTimestampMillis: Long = 0L
   var endTimestampMillis: Long = 0L
+  var availabilityStartTimeMillis: Long = 0L
+  var availabilityEndTimeMillis: Long = 0L
   @ColumnInfo(name = LAST_PLAYBACK_TIME_MILLIS) var lastPlaybackTimeMillis: Long = 0L // Epoch ms
 
   companion object {

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
@@ -27,7 +27,7 @@ class TestData() {
           id = "$i",
           movieName = "Title $i",
           landscapePoster = R.drawable.red,
-          platformType = PlatformType.TYPE_ANDROID_TV,
+          platformType = PlatformType.TYPE_UNSPECIFIED,
           platformSpecificPlaybackUri = "https://tv.com/playback/${i}",
           playbackUri = "https://tv.com/playback/${i}",
           releaseDate = 1633032875L,

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
@@ -27,7 +27,7 @@ class TestData() {
           id = "$i",
           movieName = "Title $i",
           landscapePoster = R.drawable.red,
-          platformType = PlatformType.TYPE_UNSPECIFIED,
+          platformType = PlatformType.TYPE_ANDROID_TV,
           platformSpecificPlaybackUri = "https://tv.com/playback/${i}",
           playbackUri = "https://tv.com/playback/${i}",
           releaseDate = 1633032875L,

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/model/TestData.kt
@@ -14,6 +14,7 @@
  */
 package com.google.samples.quickstart.engagesdksamples.watch.data.model
 
+import com.google.android.engage.common.datamodel.PlatformType
 import com.google.samples.quickstart.engagesdksamples.watch.R
 
 class TestData() {
@@ -26,13 +27,15 @@ class TestData() {
           id = "$i",
           movieName = "Title $i",
           landscapePoster = R.drawable.red,
+          platformType = PlatformType.TYPE_ANDROID_TV,
+          platformSpecificPlaybackUri = "https://tv.com/playback/${i}",
           playbackUri = "https://tv.com/playback/${i}",
           releaseDate = 1633032875L,
           availability = 1,
-          offerPrice = "0.00",
           durationMillis = 123456789L,
           genre = "mystery",
-          contentRatings = "PG-13"
+          contentRatingAgency = "ContentRatingAgency",
+          contentRating = "PG-13"
         )
       )
     }

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "723fc52863ed3be734f45d780ed3076e",
+    "identityHash": "93c23141d2a9be84cc38fe20f9dc2bf6",
     "entities": [
       {
         "tableName": "movie_table",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_name` TEXT NOT NULL, `landscape_poster` INTEGER NOT NULL, `playback_uri` TEXT NOT NULL, `release_date` INTEGER NOT NULL, `availability` INTEGER NOT NULL, `offer_price` TEXT NOT NULL, `duration_millis` INTEGER NOT NULL, `genre` TEXT NOT NULL, `content_ratings` TEXT NOT NULL, `currently_watching` INTEGER NOT NULL, `watch_next_type` INTEGER NOT NULL, `last_engagement_time_millis` INTEGER NOT NULL, `last_playback_time_millis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_name` TEXT NOT NULL, `landscape_poster` INTEGER NOT NULL, `platform_type` INTEGER NOT NULL, `platform_specific_playback_uri` TEXT NOT NULL, `playback_uri` TEXT NOT NULL, `release_date` INTEGER NOT NULL, `availability` INTEGER NOT NULL, `duration_millis` INTEGER NOT NULL, `genre` TEXT NOT NULL, `content_rating_agency` TEXT NOT NULL, `content_rating` TEXT NOT NULL, `currently_watching` INTEGER NOT NULL, `watch_next_type` INTEGER NOT NULL, `last_engagement_time_millis` INTEGER NOT NULL, `startTimestampMillis` INTEGER NOT NULL, `endTimestampMillis` INTEGER NOT NULL, `last_playback_time_millis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -24,6 +24,18 @@
             "fieldPath": "landscapePoster",
             "columnName": "landscape_poster",
             "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformType",
+            "columnName": "platform_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformSpecificPlaybackUri",
+            "columnName": "platform_specific_playback_uri",
+            "affinity": "TEXT",
             "notNull": true
           },
           {
@@ -45,12 +57,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "offerPrice",
-            "columnName": "offer_price",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
             "fieldPath": "durationMillis",
             "columnName": "duration_millis",
             "affinity": "INTEGER",
@@ -63,8 +69,14 @@
             "notNull": true
           },
           {
-            "fieldPath": "contentRatings",
-            "columnName": "content_ratings",
+            "fieldPath": "contentRatingAgency",
+            "columnName": "content_rating_agency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "content_rating",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -83,6 +95,18 @@
           {
             "fieldPath": "lastEngagementTimeMillis",
             "columnName": "last_engagement_time_millis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimestampMillis",
+            "columnName": "startTimestampMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimestampMillis",
+            "columnName": "endTimestampMillis",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -132,7 +156,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '723fc52863ed3be734f45d780ed3076e')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93c23141d2a9be84cc38fe20f9dc2bf6')"
     ]
   }
 }

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "93c23141d2a9be84cc38fe20f9dc2bf6",
+    "identityHash": "1c1a5b5f3bb7531120f6a0161e699ce8",
     "entities": [
       {
         "tableName": "movie_table",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_name` TEXT NOT NULL, `landscape_poster` INTEGER NOT NULL, `platform_type` INTEGER NOT NULL, `platform_specific_playback_uri` TEXT NOT NULL, `playback_uri` TEXT NOT NULL, `release_date` INTEGER NOT NULL, `availability` INTEGER NOT NULL, `duration_millis` INTEGER NOT NULL, `genre` TEXT NOT NULL, `content_rating_agency` TEXT NOT NULL, `content_rating` TEXT NOT NULL, `currently_watching` INTEGER NOT NULL, `watch_next_type` INTEGER NOT NULL, `last_engagement_time_millis` INTEGER NOT NULL, `startTimestampMillis` INTEGER NOT NULL, `endTimestampMillis` INTEGER NOT NULL, `last_playback_time_millis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_name` TEXT NOT NULL, `landscape_poster` INTEGER NOT NULL, `platform_type` INTEGER NOT NULL, `platform_specific_playback_uri` TEXT NOT NULL, `playback_uri` TEXT NOT NULL, `release_date` INTEGER NOT NULL, `availability` INTEGER NOT NULL, `duration_millis` INTEGER NOT NULL, `genre` TEXT NOT NULL, `content_rating_agency` TEXT NOT NULL, `content_rating` TEXT NOT NULL, `currently_watching` INTEGER NOT NULL, `watch_next_type` INTEGER NOT NULL, `last_engagement_time_millis` INTEGER NOT NULL, `startTimestampMillis` INTEGER NOT NULL, `endTimestampMillis` INTEGER NOT NULL, `availabilityStartTimeMillis` INTEGER NOT NULL, `availabilityEndTimeMillis` INTEGER NOT NULL, `last_playback_time_millis` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -111,6 +111,18 @@
             "notNull": true
           },
           {
+            "fieldPath": "availabilityStartTimeMillis",
+            "columnName": "availabilityStartTimeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availabilityEndTimeMillis",
+            "columnName": "availabilityEndTimeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
             "fieldPath": "lastPlaybackTimeMillis",
             "columnName": "last_playback_time_millis",
             "affinity": "INTEGER",
@@ -156,7 +168,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93c23141d2a9be84cc38fe20f9dc2bf6')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1c1a5b5f3bb7531120f6a0161e699ce8')"
     ]
   }
 }

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/data/room/schemas/com.google.samples.quickstart.engagesdksamples.watch.data.room.WatchDatabase/1.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 1,
+    "version": 2,
     "identityHash": "93c23141d2a9be84cc38fe20f9dc2bf6",
     "entities": [
       {

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
@@ -41,7 +41,7 @@ class ClusterRequestFactory(context: Context) {
 
   private val db = WatchDatabase.getDatabase(context, CoroutineScope(SupervisorJob()))
   private val movieDao = db.movieDao()
-  private val accountProfile = AccountProfile("1", "profile1")
+  private val accountProfile = AccountProfile("account_id", "profile_id")
   private val recommendationClusterTitle =
     context.resources.getString(R.string.recommendation_cluster_title)
   private val signInCardAction = context.resources.getString(R.string.sign_in_card_action_text)

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
@@ -41,7 +41,10 @@ class ClusterRequestFactory(context: Context) {
 
   private val db = WatchDatabase.getDatabase(context, CoroutineScope(SupervisorJob()))
   private val movieDao = db.movieDao()
-  private val accountProfile = AccountProfile("account_id", "profile_id")
+  private val accountProfile = AccountProfile.Builder()
+                                .setAccountId("account_id")
+                                .setProfileId("profile_id")
+                                .build()
   private val recommendationClusterTitle =
     context.resources.getString(R.string.recommendation_cluster_title)
   private val signInCardAction = context.resources.getString(R.string.sign_in_card_action_text)

--- a/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
+++ b/watch/app/src/main/java/com/google/samples/quickstart/engagesdksamples/watch/publish/ClusterRequestFactory.kt
@@ -16,6 +16,7 @@ package com.google.samples.quickstart.engagesdksamples.watch.publish
 
 import android.content.Context
 import android.net.Uri
+import com.google.android.engage.common.datamodel.AccountProfile
 import com.google.android.engage.common.datamodel.ContinuationCluster
 import com.google.android.engage.common.datamodel.FeaturedCluster
 import com.google.android.engage.common.datamodel.Image
@@ -40,6 +41,7 @@ class ClusterRequestFactory(context: Context) {
 
   private val db = WatchDatabase.getDatabase(context, CoroutineScope(SupervisorJob()))
   private val movieDao = db.movieDao()
+  private val accountProfile = AccountProfile("1", "profile1")
   private val recommendationClusterTitle =
     context.resources.getString(R.string.recommendation_cluster_title)
   private val signInCardAction = context.resources.getString(R.string.sign_in_card_action_text)
@@ -102,6 +104,8 @@ class ClusterRequestFactory(context: Context) {
     for (item in continuationList) {
       continuationCluster.addEntity(ItemToEntityConverter.convertMovie(item))
     }
+    continuationCluster.setUserConsentToSyncAcrossDevices(true)
+    continuationCluster.setAccountProfile(accountProfile)
     return PublishContinuationClusterRequest.Builder()
       .setContinuationCluster(continuationCluster.build())
       .build()


### PR DESCRIPTION
# Changes
- Updated Engage sdk to version 1.4.0
- Removed usage of Deprecated methods like setOfferPrice from movieEntity
- Added usage of attributes introduced as part of Continue Watching 2.0 effort like image themes, platform-specific playback URIs etc
- Updated test cases

# Testing
Tested read and watch apps through:
- TV emulator in Android Studio with the Engage verify app 
- pre-existing test cases provided with the sample apps